### PR TITLE
UI: allow floats for number field

### DIFF
--- a/htdocs/js/pages/PageUtils.class.js
+++ b/htdocs/js/pages/PageUtils.class.js
@@ -4959,6 +4959,7 @@ Page.PageUtils = class PageUtils extends Page.Base {
 						autocomplete: 'off',
 						spellcheck: 'false'
 					};
+					if (param.variant == 'number') text_args.step = 'any';
 					if (!param.variant || param.variant.match(/^(password|text|tel)$/)) {
 						// only show explorer icon for non-validating text variants
 						html += explore_start + self.getFormText(text_args) + explore_end;


### PR DESCRIPTION
This allows `temperature` field in `xyplug-ai` to be modified.

For the long term, it's better to split `number` into `integer` and `float`, but for now, this quick fix works.